### PR TITLE
DuckDuckGo Bug Fix

### DIFF
--- a/modules/search.py
+++ b/modules/search.py
@@ -136,7 +136,7 @@ def bing(phenny, input):
 bing.commands = ['bing']
 bing.example = '.bing swhack'
 
-r_duck = re.compile(r'nofollow" class="[^"]+" href="(.*?)">')
+r_duck = re.compile(r'nofollow" class="[^"]+" href="(http.*?)">')
 
 def duck_search(query): 
    query = query.replace('!', '')


### PR DESCRIPTION
Modified the r_duck reg expr in modules/search.py to skip over the sponsered links on the results page which don't return valid links.
