### PR TITLE
Better dealing with encoding for url titles.

### DIFF
--- a/web.py
+++ b/web.py
@@ -21,9 +21,14 @@ def get(uri):
     if not uri.startswith('http'): 
         return
     u = urllib.request.urlopen(uri)
-    bytes = u.read()
+    try:
+        bytes = u.read()
+    except httpclient.IncompleteRead as e:
+        bytes = e.partial
     try:
         bytes = bytes.decode('utf-8')
+    except UnicodeDecodeError:
+        bytes = bytes.decode('windows-1251')
     except UnicodeDecodeError:
         bytes = bytes.decode('ISO-8859-1')
     u.close()


### PR DESCRIPTION
... already read data can be retained.

http://bobrochel.blogspot.ca/2010/11/bad-servers-chunked-encoding-and.html

Added handler for windows-1252 encoding before ISO, because windows-1252 is more common still.
